### PR TITLE
fix: 修复无限重连以及ws重复监听的问题

### DIFF
--- a/src/client/session/session.ts
+++ b/src/client/session/session.ts
@@ -1,8 +1,8 @@
-import { WsObjRequestOptions, EventTypes, SessionEvents, GetWsParam, SessionRecord } from '@src/types/websocket-types';
-import { Ws } from '@src/client/websocket/websocket';
-import { EventEmitter } from 'ws';
-import resty, { RequestOptions } from 'resty-client';
-import { addUserAgent, addAuthorization, buildUrl } from '@src/utils/utils';
+import {GetWsParam, SessionEvents, SessionRecord, WsObjRequestOptions} from '@src/types/websocket-types';
+import {Ws} from '@src/client/websocket/websocket';
+import {EventEmitter} from 'ws';
+import resty from 'resty-client';
+import {addAuthorization} from "@src/utils/utils";
 
 export default class Session {
   config: GetWsParam;
@@ -10,6 +10,7 @@ export default class Session {
   ws!: Ws;
   event!: EventEmitter;
   sessionRecord: SessionRecord | undefined;
+
   constructor(config: GetWsParam, event: EventEmitter, sessionRecord?: SessionRecord) {
     this.config = config;
     this.event = event;
@@ -17,46 +18,32 @@ export default class Session {
     if (sessionRecord) {
       this.sessionRecord = sessionRecord;
     }
-    this.createSession();
+    this.createSession()
   }
 
   // 新建会话
-  async createSession() {
+  createSession() {
     this.ws = new Ws(this.config, this.event, this.sessionRecord || undefined);
     // 拿到 ws地址等信息
-    // 添加鉴权信息
-    addAuthorization(WsObjRequestOptions.headers, this.config.appID, this.config.token);
-
-    const wsData = await this.getWsInfo(WsObjRequestOptions);
-    // 连接到 ws
-    this.ws.createWebsocket(wsData);
-
-    this.event.on(SessionEvents.EVENT_WS, (data: EventTypes) => {
-      // 服务端通知重连
-      if (data.eventType === SessionEvents.RECONNECT) {
-        this.ws.reconnect();
-      }
-    });
-    return this.ws;
+    const reqOptions = WsObjRequestOptions(this.config.sandbox)
+    addAuthorization(reqOptions.headers, this.config.appID, this.config.token)
+    resty.create(reqOptions)
+      .get(reqOptions.url as string, {})
+      .then(r => {
+        const wsData = r.data
+        if (!wsData) throw new Error("获取ws连接信息异常")
+        this.ws.createWebsocket(wsData);
+      }).catch(e => {
+      console.log('[ERROR] createSession: ', e)
+      this.event.emit(SessionEvents.EVENT_WS, {
+        eventType: SessionEvents.DISCONNECT,
+        eventMsg: this.sessionRecord
+      })
+    })
   }
 
   // 关闭会话
-  async closeSession() {
+  closeSession() {
     this.ws.closeWs();
-  }
-
-  // 拿到 ws地址等信息
-  async getWsInfo(options: RequestOptions) {
-    const wsService = resty.create(options);
-    const wsData: any = {
-      data: {},
-    };
-
-    const botUrl = buildUrl(options.url, this.config.sandbox);
-
-    await wsService.get(botUrl, {}).then((res) => {
-      wsData.data = res.data;
-    });
-    return wsData.data;
   }
 }

--- a/src/types/websocket-types.ts
+++ b/src/types/websocket-types.ts
@@ -1,5 +1,7 @@
-import { apiVersion } from '@src/openapi/v1/openapi';
-import { getURL } from '@src/openapi/v1/resource';
+import {apiVersion} from '@src/openapi/v1/openapi';
+import {getURL} from '@src/openapi/v1/resource';
+import {buildUrl} from "@src/utils/utils";
+
 // websocket建立成功回包
 export interface wsResData {
   op: number; // opcode ws的类型
@@ -27,9 +29,10 @@ export interface EventTypes {
 export interface GetWsParam {
   appID: string;
   token: string;
+  sandbox: boolean;
   shards?: Array<number>;
   intents?: Array<AvailableIntentsEventsEnum>;
-  sandbox?: boolean;
+  maxRetry?: number;
 }
 
 // 请求ws地址回包对象
@@ -168,10 +171,12 @@ export const WebsocketCloseReason = [
   {
     code: 4008,
     reason: '发送 payload 过快，请重新连接，并遵守连接后返回的频控信息',
+    resume: true
   },
   {
     code: 4009,
     reason: '连接过期，请重连',
+    resume: true
   },
   {
     code: 4010,
@@ -253,12 +258,13 @@ export const SessionEvents = {
   DISCONNECT: 'DISCONNECT', // 断线
   EVENT_WS: 'EVENT_WS', // 内部通信
   RESUMED: 'RESUMED', // 重连
+  DEAD: 'DEAD'// 连接已死亡，请检查网络或重启
 };
 
 // ws地址配置
-export const WsObjRequestOptions = {
+export const WsObjRequestOptions = (sandbox: boolean) => ({
   method: 'GET' as const,
-  url: getURL('wsInfo'),
+  url: buildUrl(getURL('wsInfo'), sandbox),
   headers: {
     Accept: '*/*',
     'Accept-Encoding': 'utf-8',
@@ -267,4 +273,4 @@ export const WsObjRequestOptions = {
     'User-Agent': apiVersion,
     Authorization: '',
   },
-};
+});


### PR DESCRIPTION
buildUrl改回了在websocket-types.ts中调用，因为在创建session时单独处理WsObjRequestOptions对象的url参数，会导致重连时，对象指针不变，拼接出错误的url，暂未想到其他的调用buildUrl方法