### PR TITLE
fix: 参考最新消息返回体和最新API文档，对Ark与IMessage做出一点调整

### DIFF
--- a/src/types/openapi/v1/message.ts
+++ b/src/types/openapi/v1/message.ts
@@ -42,8 +42,8 @@ export interface Ark {
 // ArkKV Ark 键值对
 export interface ArkKV {
   key: string;
-  value: string;
-  obj: ArkObj[];
+  value?: string;
+  obj?: ArkObj[]; //更好的适配API给出的模板
 }
 
 // ArkObj Ark 对象
@@ -74,6 +74,8 @@ export interface IMessage {
   ark: Ark; // ark 消息
   seq?: number; // 用于消息间的排序
   seq_in_channel?: string; // 子频道消息 seq
+  direct_message?:boolean; //是否私聊消息
+  src_guild_id?:string; //私聊消息实际来源频道ID
 }
 
 // 接口返回的数据多一层message


### PR DESCRIPTION
### 最新消息私信返回体如下，增加`direct_message`，`src_guild_id`字段对私聊消息适配
![](https://cdn.ethreal.cn/img/1655713667909-1655713668.png)

### API文档中Ark 模板中`value`和`obj`字段不是必要的，做出通用性调整
![](https://cdn.ethreal.cn/img/1655713832068-1655713832.png)